### PR TITLE
feat: add +18 content flag and filtering

### DIFF
--- a/prisma/migrations/20250915000000_add_adult_flag/migration.sql
+++ b/prisma/migrations/20250915000000_add_adult_flag/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Module` ADD COLUMN `adult` BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Module {
   sourceCode       String?
   published        Boolean    @default(true)
   aproved          Boolean    @default(true)
+  adult            Boolean    @default(false)
   author           User?      @relation(fields: [authorId], references: [id])
   authorId         Int?
   icon             String     @default("")

--- a/src/lib/components/modules/modulesListItem.svelte
+++ b/src/lib/components/modules/modulesListItem.svelte
@@ -10,6 +10,9 @@
     <div class="flex items-center">
         <img class="h-10 w-10 rounded-full" src={PUBLIC_MINIO_URL + module.icon} alt="{module.name} zumito module icon">
         <span class="ml-3 font-medium">{module.name}</span>
+        {#if module.adult}
+            <span class="ml-2 rounded bg-red-600 px-1.5 text-xs font-bold text-white">+18</span>
+        {/if}
     </div>
     <div class="flex gap-3">
         <a href="/module/{module.name}" class="text-gray-500 hover:text-gray-700">

--- a/src/routes/(app)/+page.server.ts
+++ b/src/routes/(app)/+page.server.ts
@@ -2,10 +2,17 @@ import type { RequestHandler } from '@sveltejs/kit';
 import prisma from '$lib/prisma';
 
 export async function load({ url }) {
-	const selectedFeatures = url.searchParams.get('features')?.split(',') || [];
+        const selectedFeatures = url.searchParams.get('features')?.split(',') || [];
 
-	const modules = await prisma.module.findMany({
+        const baseWhere: any = {
+            published: true,
+            aproved: true,
+            adult: false
+        };
+
+        const modules = await prisma.module.findMany({
         where: selectedFeatures.length > 0 ? {
+            ...baseWhere,
             features: {
                 some: {
                     name: {
@@ -13,7 +20,7 @@ export async function load({ url }) {
                     }
                 }
             }
-        } : {},
+        } : baseWhere,
         orderBy: {
             installs: {
                 _count: 'desc'
@@ -52,18 +59,18 @@ export async function load({ url }) {
 
 	// Calcular estadísticas dinámicas
 	const [moduleCount, downloadCount, developerCount, featureCount, popularFeatures] = await Promise.all([
-		prisma.module.count({
-			where: { published: true }
-		}),
-		prisma.install.count(),
-		prisma.module.findMany({
-			where: { published: true },
-			select: { authorId: true },
-			distinct: ['authorId']
-		}),
-		prisma.feature.count(),
-		// Obtener features populares con conteo de módulos
-		prisma.feature.findMany({
+                prisma.module.count({
+                        where: { published: true, adult: false }
+                }),
+                prisma.install.count(),
+                prisma.module.findMany({
+                        where: { published: true, adult: false },
+                        select: { authorId: true },
+                        distinct: ['authorId']
+                }),
+                prisma.feature.count(),
+                // Obtener features populares con conteo de módulos
+                prisma.feature.findMany({
 			select: {
 				id: true,
 				name: true,

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -230,7 +230,10 @@
         <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
             {#each modules as module}
                 <article class="group overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-pink-200 hover:shadow-lg dark:border-gray-700 dark:bg-gray-800 dark:hover:border-pink-600">
-                    <a href="/module/{module.name}" class="block">
+                    <a href="/module/{module.name}" class="block relative">
+                        {#if module.adult}
+                            <span class="absolute top-2 right-2 rounded bg-red-600 px-2 py-1 text-xs font-bold text-white">+18</span>
+                        {/if}
                         <!-- Header with icon and basic info -->
                         <div class="p-6 pb-4">
                             <div class="mb-4 flex items-start gap-4">

--- a/src/routes/(app)/module/[name]/+page.svelte
+++ b/src/routes/(app)/module/[name]/+page.svelte
@@ -94,9 +94,14 @@
                     <img src={PUBLIC_MINIO_URL + module.icon} alt="{module.name} icon" class="h-16 w-16 rounded-xl border border-gray-200 object-cover shadow-lg lg:h-20 lg:w-20 dark:border-gray-700">
                 {/if}
                 <div class="flex-1">
-                    <h1 class="bg-gradient-to-r from-pink-600 to-purple-600 bg-clip-text text-4xl font-bold text-transparent lg:text-5xl">
-                        {module.name}
-                    </h1>
+                    <div class="flex items-center gap-3">
+                        <h1 class="bg-gradient-to-r from-pink-600 to-purple-600 bg-clip-text text-4xl font-bold text-transparent lg:text-5xl">
+                            {module.name}
+                        </h1>
+                        {#if module.adult}
+                            <span class="rounded bg-red-600 px-2 py-1 text-sm font-semibold text-white">+18</span>
+                        {/if}
+                    </div>
                     {#if module.shortDescription}
                         <p class="mt-3 hidden text-lg text-gray-600 sm:block dark:text-gray-300">{module.shortDescription}</p>
                     {/if}

--- a/src/routes/(app)/module/[name]/edit/+page.server.ts
+++ b/src/routes/(app)/module/[name]/edit/+page.server.ts
@@ -27,6 +27,7 @@ export async function load({ params, cookies }) {
             instructions: true,
             published: true,
             aproved: true,
+            adult: true,
             authorId: true,
             icon: true,
             images: {
@@ -78,6 +79,7 @@ export const actions = {
         const npm = inputs.get('npm') as string;
         let iconUrl = inputs.get('iconUrl') as string | null;
         const selectedFeatures = inputs.getAll('features') as string[];
+        const adult = inputs.has('adult');
         const removedImages = inputs.getAll('removedImages') as string[];
 
         // Procesar icono: si hay archivo, subirlo a Minio
@@ -174,7 +176,8 @@ export const actions = {
             },
             features: {
                 set: selectedFeatures.map((name) => ({ name }))
-            }
+            },
+            adult
         };
 
         // Solo actualizar el icono si hay iconUrl (ya sea nueva URL tras subir archivo o URL existente)

--- a/src/routes/(app)/module/[name]/edit/+page.svelte
+++ b/src/routes/(app)/module/[name]/edit/+page.svelte
@@ -16,6 +16,7 @@ import IconUploader from '$lib/components/IconUploader.svelte';
     let shortDescription = data.module.shortDescription || '';
     let description = data.module.description || '';
     let npm = data.module.npm || '';
+    let isAdult = data.module.adult || false;
 
 // Aplicar la corrección a las URLs
 let iconUrl: string | null = data.module.icon ? PUBLIC_MINIO_URL + data.module.icon : null;
@@ -195,6 +196,11 @@ let images: { id: string, url: string, relativePath?: string, file?: File }[] = 
                     </div>
                 {/each}
             </div>
+        </div>
+
+        <div class="flex items-center gap-2">
+            <input type="checkbox" id="adult" name="adult" bind:checked={isAdult} class="h-4 w-4 rounded border-gray-300 bg-gray-100 text-pink-600 focus:ring-2 focus:ring-pink-500 dark:border-gray-600 dark:bg-gray-700 dark:ring-offset-gray-800 dark:focus:ring-pink-600">
+            <label for="adult" class="text-sm font-medium text-gray-900 dark:text-gray-300">Contains +18 content</label>
         </div>
 
         <div>

--- a/src/routes/(app)/modules/+page.server.ts
+++ b/src/routes/(app)/modules/+page.server.ts
@@ -5,6 +5,7 @@ export const load = async ({ url }) => {
     const selectedFeatures = url.searchParams.get('features')?.split(',').filter(Boolean) || [];
     const sortBy = url.searchParams.get('sort') || 'latest';
     const priceFilter = url.searchParams.get('price') || 'all';
+    const show18 = url.searchParams.get('show18') === 'true';
     const page = parseInt(url.searchParams.get('page') || '1');
     const limit = 12;
     const offset = (page - 1) * limit;
@@ -13,6 +14,7 @@ export const load = async ({ url }) => {
     const whereConditions: any = {
         published: true,
         aproved: true,
+        ...(show18 ? {} : { adult: false })
     };
 
     if (searchQuery) {
@@ -164,7 +166,8 @@ export const load = async ({ url }) => {
                                         ]
                                     }),
                                     ...(priceFilter === 'free' && { price: 0 }),
-                                    ...(priceFilter === 'paid' && { price: { gt: 0 } })
+                                    ...(priceFilter === 'paid' && { price: { gt: 0 } }),
+                                    ...(show18 ? {} : { adult: false })
                                 }
                             }
                         }
@@ -196,6 +199,7 @@ export const load = async ({ url }) => {
             selectedFeatures,
             sortBy,
             priceFilter,
+            show18,
             allFeatures: JSON.parse(JSON.stringify(allFeatures)),
             featureStats: featureStatsObject
         };
@@ -210,6 +214,7 @@ export const load = async ({ url }) => {
             selectedFeatures: [],
             sortBy: 'latest',
             priceFilter: 'all',
+            show18,
             allFeatures: [],
             featureStats: {}
         };

--- a/src/routes/(app)/modules/+page.svelte
+++ b/src/routes/(app)/modules/+page.svelte
@@ -12,6 +12,7 @@
     let selectedFeatures = data.selectedFeatures || [];
     let selectedSort = data.sortBy;
     let selectedPrice = data.priceFilter;
+    let show18 = data.show18;
     let showMobileFilters = false;
 
     const placeholderImage = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBwgHBgkIBwgKCgkLDRYPDQwMDRsUFRAWIB0iIiAdHx8kKDQsJCYxJx8fLT0tMTU3Ojo6Iys/RD84QzQ5OjcBCgoKDQwNGg8PGjclHyU3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3N//AABEIALcAwwMBIgACEQEDEQH/xAAbAAEAAgMBAQAAAAAAAAAAAAAABAUBAgMGB//EAC4QAQACAQIEBAQGAwAAAAAAAAABAgMEEQUhMVESEyJBUmFxkSNCgaHB0TIzkv/EABcBAQEBAQAAAAAAAAAAAAAAAAABAgP/xAAWEQEBAQAAAAAAAAAAAAAAAAAAARH/2gAMAwEAAhEDEQA/APoIDo5gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM+G3wz9gYAAAAAAAAAAAAAAAAAAAAB202nvqL+GnKI627A548d8t4pjrNrT7QstPwusbTntvPw16fdM0+DHp6eHHH1n3l1ZtakaY8OPF/rx1r9IdN2BFa3pTJG16Vt9Y3Rc3DcF+dN8c/LnH2TAFFqNFmwbzMeKnxVR3pULV8Ppl3ti2pft7S1KzYpx0vgy0tNbY7bx8mFRoAAAAREzMREbzPtAt+F6etMUZpje9uk9oKRAjRamY38mdvnMOF6Wpaa3rNZj2mHpEfW6euowzy9dY3rP8M61iiAaZAAAZpW17xSkb2mdogHTTYL6jLFKfrPaF7hxUw44pSNoj92mk09dNiisc7TztPeXZm1qQARQAAAAAAAHmgG2AABe8PvF9Jj2/LHhn9FE7abU5NNfenOJ61npKVYv2uW8Y8dr26VjdBjiuPbnivE9o2Q9XrL6n07eGkflj+UxdRgGmQABbcM0vl0868eu0emO0InDtN5+XxWj8OnX5z2XSWtSADKgAAAAAAAAAKu3Cr/lzVn612Rs2iz4udqbx3rzXoupjzQvdRo8OfeZr4b/FVVanSZdPO9o8VPa0LqYjgKgAAAA2x0tlyVpSN7WnaGq34ZpvLx+bePXaOXyhKsSsGKuDFXHXpHWe8ugMtAAAAAAAAAAAAAABMRMbTG8ACs1nDtt76ePrT+la9Kh63Q1z73x7VyftZZUsUwzatqWmtomLR1iWGmQEjR6W2pv2pH+VgdOHaXzr+ZePw6z/ANSuWKUrjpFKRtWOkMsWtyAAAAAAAAAAAAAAAAAAAAI+r0mPUxz9N46WhXW4bqInaPDaO8SuRdTFZg4XO++e0bfDX+1lSlcdYrSsVrHSIZE1cAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAf/9k=';
@@ -33,6 +34,7 @@
         if (selectedFeatures.length > 0) params.set('features', selectedFeatures.join(','));
         if (selectedSort !== 'latest') params.set('sort', selectedSort);
         if (selectedPrice !== 'all') params.set('price', selectedPrice);
+        if (show18) params.set('show18', 'true');
         
         const newUrl = params.toString() ? `/modules?${params.toString()}` : '/modules';
         goto(newUrl, { replaceState: true });
@@ -43,6 +45,7 @@
         selectedFeatures = [];
         selectedSort = 'latest';
         selectedPrice = 'all';
+        show18 = false;
         updateFilters();
     }
 
@@ -203,6 +206,19 @@
                         </div>
                     </div>
 
+                    <!-- Adult Filter -->
+                    <div class="pt-4">
+                        <label class="flex items-center">
+                            <input
+                                type="checkbox"
+                                bind:checked={show18}
+                                on:change={updateFilters}
+                                class="text-pink-600 focus:ring-pink-500 dark:bg-gray-700 dark:border-gray-600"
+                            />
+                            <span class="ml-2 text-sm dark:text-gray-300">Show +18 modules</span>
+                        </label>
+                    </div>
+
                     <!-- Features -->
                     <div>
                         <span class="mb-3 block text-sm font-medium text-gray-700 dark:text-gray-300">Features</span>
@@ -264,8 +280,11 @@
                 {#if data.modules.length > 0}
                     <div class="mb-8 grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
                         {#each data.modules as module}
-                            <a href="/module/{module.name}" 
-                               class="group rounded-xl border border-gray-200 bg-white p-6 shadow-sm transition-all duration-200 hover:scale-105 hover:shadow-lg dark:border-gray-700 dark:bg-gray-800">
+                            <a href="/module/{module.name}"
+                               class="group relative rounded-xl border border-gray-200 bg-white p-6 shadow-sm transition-all duration-200 hover:scale-105 hover:shadow-lg dark:border-gray-700 dark:bg-gray-800">
+                                {#if module.adult}
+                                    <span class="absolute top-2 right-2 rounded bg-red-600 px-2 py-1 text-xs font-bold text-white">+18</span>
+                                {/if}
                                 <div class="mb-4 flex items-start gap-4">
                                     <img src="{placeholderImage}" alt="" class="h-16 w-16 rounded-lg border border-gray-200 object-cover dark:border-gray-600">
                                     <div class="min-w-0 flex-1">

--- a/src/routes/(app)/submit/+page.server.ts
+++ b/src/routes/(app)/submit/+page.server.ts
@@ -20,10 +20,11 @@ export const actions = {
 		const name = inputs.get('name') as string;
 		const description = inputs.get('description') as string;
 		const shortDescription = inputs.get('shortDescription') as string;
-		const npm = inputs.get('npm') as string;
-		const iconUrl = inputs.get('iconUrl') as string;
-		const imageUrls = inputs.getAll('imageUrls') as string[];
-		const selectedFeatures = inputs.getAll('features') as string[];
+                const npm = inputs.get('npm') as string;
+                const iconUrl = inputs.get('iconUrl') as string;
+                const imageUrls = inputs.getAll('imageUrls') as string[];
+                const selectedFeatures = inputs.getAll('features') as string[];
+                const adult = inputs.has('adult');
 		
 		
 		if (name === '') 			return { status: 400, error: 'Name is required' };
@@ -55,11 +56,12 @@ export const actions = {
 				images: {
 					create: imageUrls.map(url => ({ url: url }))
 				},
-				features: {
-					connect: selectedFeatures.map(featureName => ({ name: featureName }))
-				}
-			},
-		});
+                                features: {
+                                        connect: selectedFeatures.map(featureName => ({ name: featureName }))
+                                },
+                                adult: adult
+                        },
+                });
 
 		return redirect(303, `/module/${module.name}`);
 	},

--- a/src/routes/(app)/submit/+page.svelte
+++ b/src/routes/(app)/submit/+page.svelte
@@ -174,6 +174,11 @@
               </div>
           </div>
 
+          <div class="flex items-center gap-2">
+              <input type="checkbox" id="adult" name="adult" class="w-4 h-4 text-pink-600 bg-gray-100 border-gray-300 rounded focus:ring-pink-500 dark:focus:ring-pink-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
+              <label for="adult" class="text-sm font-medium text-gray-900 dark:text-gray-300">Contains +18 content</label>
+          </div>
+
           <div>
               <label for="first_name" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
                   Price


### PR DESCRIPTION
## Summary
- add `adult` flag to modules with Prisma migration
- support marking modules as +18 in submit and edit forms
- show +18 badges and filtering controls in module lists and details

## Testing
- `npx prisma generate`
- `npm run check` *(fails: Property 'message' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ace1de1508832f9ebd3dc600dc3251